### PR TITLE
Replace motion with next-view-transitions for image transitions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -85,3 +85,7 @@ html {
 [role='dialog'] {
   height: 100svh;
 }
+
+::view-transition-group(header) {
+  z-index: 100; /* Ensure the header is always on top when picture transition*/
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
       <html lang="en">
         <body className={`${GeistMono.className}`}>
           <CartProvider>
-            <div className="flex flex-col min-h-screen h-screen mx-5 overflow-y-scroll">
+            <div className="flex flex-col mx-5 overflow-y-scroll">
               <Header />
               {children}
             </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,9 @@
 import './globals.css';
 import { GeistMono } from 'geist/font/mono';
 import { Metadata, Viewport } from 'next';
+import { ViewTransitions } from 'next-view-transitions';
 import { CartProvider } from '@/components/cart-context';
+import { Header } from '@/components/header';
 
 export const metadata: Metadata = {
   title: 'NEXYZY',
@@ -18,14 +20,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={`${GeistMono.className}`}>
-        <CartProvider>
-          <div className="flex flex-col min-h-screen h-screen mx-5 overflow-y-scroll">
-            {children}
-          </div>
-        </CartProvider>
-      </body>
-    </html>
+    <ViewTransitions>
+      <html lang="en">
+        <body className={`${GeistMono.className}`}>
+          <CartProvider>
+            <div className="flex flex-col min-h-screen h-screen mx-5 overflow-y-scroll">
+              <Header />
+              {children}
+            </div>
+          </CartProvider>
+        </body>
+      </html>
+    </ViewTransitions>
   );
 }

--- a/app/p/[slug]/pdp.tsx
+++ b/app/p/[slug]/pdp.tsx
@@ -1,28 +1,52 @@
 'use client';
 
+import { useEffect } from 'react';
+import { useTransitionRouter } from 'next-view-transitions';
 import { motion } from 'motion/react';
 import { notFound, redirect } from 'next/navigation';
 import { getProductById } from '@/lib/products';
 import { AddToCart } from '@/components/add-to-cart';
-import { Header } from '@/components/header';
 import { ProductImage } from '@/components/product-image';
 
 export default function PDP({ slug }: { slug: string }) {
   const product = getProductById(slug);
+  const router = useTransitionRouter();
 
   if (!product) {
     notFound();
   }
 
   const handleBack = () => {
-    redirect('/');
+    router.back();
   };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleBack();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleBack]);
 
   return (
     <div className="flex flex-col min-h-screen">
-      <Header isBackVisible={true} onBack={handleBack} />
-      <main className="flex flex-col items-center justify-between pt-[20px]">
-        <div className="w-full max-w-4xl mx-auto flex-grow flex flex-col items-center justify-center p-4">
+      <main
+        className="flex flex-col items-center justify-between pt-[20px]"
+        style={{
+          top: '0',
+          height:
+            'calc(100vh - 80px - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
+          paddingTop: 'calc(20px + env(safe-area-inset-top))',
+          paddingBottom: '0',
+        }}
+      >
+        <div className="w-full max-w-2xl mx-auto flex-grow flex flex-col items-center justify-center aspect-square">
           <ProductImage
             product={product}
             maxWidth="100%"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,130 +1,23 @@
 'use client';
 
-import { useState, useEffect, useCallback, useTransition } from 'react';
-import { motion, AnimatePresence } from 'motion/react';
-import { products, Product } from '@/lib/products';
-import { Header } from '@/components/header';
-import { AddToCart } from '@/components/add-to-cart';
+import { Link } from 'next-view-transitions';
+import { products } from '@/lib/products';
 import { ProductImage } from '@/components/product-image';
 
 export default function Page() {
-  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
-  const [_, startTransition] = useTransition();
-
-  const handleProductClick = (product: Product) => {
-    startTransition(() => {
-      setSelectedProduct(product);
-      window.history.pushState(null, '', `/p/${product.id}`);
-    });
-  };
-
-  const handleBack = useCallback(() => {
-    startTransition(() => {
-      setSelectedProduct(null);
-      window.history.pushState(null, '', '/');
-    });
-  }, []);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (selectedProduct) {
-        if (event.key === 'Escape') {
-          handleBack();
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [selectedProduct, handleBack]);
-
-  useEffect(() => {
-    const handlePopState = () => {
-      const productId = window.location.pathname.split('/').pop();
-      if (productId && productId !== '') {
-        const product = products.find((p) => p.id === productId);
-        if (product) {
-          setSelectedProduct(product);
-        } else {
-          setSelectedProduct(null);
-        }
-      } else {
-        setSelectedProduct(null);
-      }
-    };
-
-    window.addEventListener('popstate', handlePopState);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, []);
-
   return (
     <div className="flex flex-col min-h-screen">
-      <Header isBackVisible={!!selectedProduct} onBack={handleBack} />
       <main className="flex-grow relative pt-12">
-        <motion.div
-          className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-9 gap-x-5 gap-y-12 pb-8"
-          animate={{ opacity: selectedProduct ? 0 : 1 }}
-          transition={{ duration: 0.3 }}
-        >
+        <div className="grid grid-cols-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-9 gap-x-5 gap-y-12 pb-8">
           {products.map((product) => (
-            <div
-              key={product.id}
-              className="group cursor-pointer"
-              onClick={() => handleProductClick(product)}
-            >
-              <ProductImage
-                product={product}
-                layoutId={`product-image-${product.id}`}
-              />
+            <Link key={product.id} href={`/p/${product.id}`}>
+              <ProductImage product={product} />
               <p className="font-medium text-center font-mono uppercase">
                 {product.id.split('-').slice(0, -1).join('-')}
               </p>
-            </div>
+            </Link>
           ))}
-        </motion.div>
-
-        <AnimatePresence>
-          {selectedProduct && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="fixed inset-0 flex flex-col items-center justify-between bg-white bg-opacity-90"
-              style={{
-                top: '0',
-                height:
-                  'calc(100vh - 80px - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
-                paddingTop: 'calc(20px + env(safe-area-inset-top))',
-                paddingBottom: '0',
-              }}
-            >
-              <div className="w-full max-w-4xl mx-auto flex-grow flex flex-col items-center justify-center p-4">
-                <ProductImage
-                  product={selectedProduct}
-                  maxWidth="100%"
-                  maxHeight="calc(100vh - 250px - env(safe-area-inset-top) - env(safe-area-inset-bottom))"
-                  className="w-full"
-                  layoutId={`product-image-${selectedProduct.id}`}
-                />
-              </div>
-
-              <motion.div
-                className="w-full max-w-md mx-auto p-4"
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.3, delay: 0.3 }}
-              >
-                <AddToCart product={selectedProduct} />
-              </motion.div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        </div>
       </main>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,27 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Link } from 'next-view-transitions';
 import { products } from '@/lib/products';
 import { ProductImage } from '@/components/product-image';
+import { throttle } from '@/lib/utils';
 
 export default function Page() {
+  useEffect(() => {
+    const sessionKey = 'scroll_/';
+    const savedPosition = sessionStorage.getItem(sessionKey);
+    if (savedPosition) {
+      window.scrollTo(0, parseInt(savedPosition));
+    }
+
+    const handleScroll = throttle(() => {
+      sessionStorage.setItem(sessionKey, window.scrollY.toString());
+    }, 500);
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
   return (
     <div className="flex flex-col min-h-screen">
       <main className="flex-grow relative pt-12">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,25 +1,34 @@
 'use client';
 
+import { useState, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { useTransitionRouter } from 'next-view-transitions';
 import { MainMenu } from './main-menu';
 import { Cart } from './cart';
-import { useState } from 'react';
 import { useCart } from './cart-context';
 
-interface HeaderProps {
-  isBackVisible: boolean;
-  onBack: any;
-}
-
-export function Header({ isBackVisible, onBack }: HeaderProps) {
+export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const router = useTransitionRouter();
+
   const { items } = useCart();
+
+  const handleBack = useCallback(() => {
+    router.back();
+  }, []);
+
+  const isHomePage = pathname === '/';
 
   const totalQuantity = items.reduce((total, item) => total + item.quantity, 0);
 
   return (
-    <nav className="flex items-center justify-between py-0 px-5 fixed top-0 left-0 right-0 z-10 bg-white">
+    <nav
+      style={{ viewTransitionName: 'header' }}
+      className="flex items-center justify-between py-0 px-5 fixed top-0 left-0 right-0 z-10 bg-white"
+    >
       <div className="flex items-center">
-        <MainMenu isBackVisible={isBackVisible} onBack={onBack} />
+        <MainMenu isBackVisible={!isHomePage} onBack={handleBack} />
       </div>
       <div className="flex items-center">
         <button

--- a/components/product-image.tsx
+++ b/components/product-image.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { motion } from 'motion/react';
 import { Product } from '@/lib/products';
 
 interface ProductImageProps {
@@ -8,7 +7,6 @@ interface ProductImageProps {
   maxWidth?: string;
   maxHeight?: string;
   className?: string;
-  layoutId?: string;
 }
 
 export function ProductImage({
@@ -16,10 +14,9 @@ export function ProductImage({
   maxWidth = '100%',
   maxHeight = 'none',
   className = '',
-  layoutId,
 }: ProductImageProps) {
   return (
-    <motion.div
+    <div
       className={`relative mb-1 ${className}`}
       style={{
         width: '100%',
@@ -28,17 +25,17 @@ export function ProductImage({
         aspectRatio: '1',
         overflow: 'hidden',
       }}
-      layoutId={layoutId}
     >
       <Image
         src={product.image}
         alt={product.name}
         fill
+        style={{ viewTransitionName: product.id }}
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
         className="object-contain transition-opacity duration-200 aspect-square"
         loading="eager"
         decoding="sync"
       />
-    </motion.div>
+    </div>
   );
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,28 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function throttle<T extends any[]>(
+  fn: (...args: T) => void,
+  delay: number
+) {
+  let isThrottled = false;
+  let lastArgs: T | null = null;
+
+  return (...args: T) => {
+    lastArgs = args;
+
+    if (!isThrottled) {
+      fn(...args);
+      isThrottled = true;
+
+      setTimeout(() => {
+        isThrottled = false;
+        if (lastArgs) {
+          fn(...lastArgs);
+          lastArgs = null;
+        }
+      }, delay);
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lucide-react": "^0.469.0",
     "motion": "^11.15.0",
     "next": "15.1.1-canary.22",
+    "next-view-transitions": "^0.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       next:
         specifier: 15.1.1-canary.22
         version: 15.1.1-canary.22(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-view-transitions:
+        specifier: ^0.3.4
+        version: 0.3.4(next@15.1.1-canary.22(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -721,6 +724,13 @@ packages:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  next-view-transitions@0.3.4:
+    resolution: {integrity: sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ==}
+    peerDependencies:
+      next: '>=14.0.0'
+      react: ^18.2.0
+      react-dom: ^18.2.0
 
   next@15.1.1-canary.22:
     resolution: {integrity: sha512-hphbkY9U2YKMHyuDmaD3JsCM8sVrOU4X1LfyUH8jWAGkbF0uNFMKHO0OWsp3R6pd0i1vyDBI+lxFXBxYi6A5ZA==}
@@ -1589,6 +1599,12 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.8: {}
+
+  next-view-transitions@0.3.4(next@15.1.1-canary.22(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      next: 15.1.1-canary.22(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   next@15.1.1-canary.22(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:


### PR DESCRIPTION
Hi Lee, I've reimplemented product image transitions using view-transitions API instead of motion. 

Made a few improvements to make things work better:
- Extracted Header component to layout
- Keep the same aspect ratio between the home page image and the product page image to avoid strange shadows appearing
- There seems to be an issue with link restoration. I tried using scroll={false}, but it didn't work, so I manually recorded the page's scroll position to ensure it returns to the previous height when going back to the home page, so that the transition of the images is smooth

Here's the demo: https://nextzy-vt.vercel.app/

Thanks for checking this out!